### PR TITLE
Fix correct flag parsing

### DIFF
--- a/src/Quizify.jl
+++ b/src/Quizify.jl
@@ -76,7 +76,10 @@ function build_quiz_html(path::AbstractString)::String
         for (j, answer) in enumerate(question["answers"])
             aid      = "q$(i)_a$(j)"
             feedback = answer["feedback"]
-            correct  = startswith(lowercase(feedback), "correct")
+            # Use the explicit `correct` field if provided, otherwise
+            # fall back to inferring from the feedback text for
+            # backwards compatibility.
+            correct  = haskey(answer, "correct") ? answer["correct"] : startswith(lowercase(feedback), "correct")
             html *= """
             <button type="button"
                     class="quiz-answer answer-$(qid)"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Quizify
 
 # Path to the test JSON fixture
 const TEST_JSON = joinpath(@__DIR__, "test_quiz.json")
+const TEST_JSON_ALT = joinpath(@__DIR__, "test_quiz_alt.json")
 
 @testset "Quizify core functionality" begin
 
@@ -27,4 +28,11 @@ const TEST_JSON = joinpath(@__DIR__, "test_quiz.json")
     html2 = Quizify.show_quiz_from_json(TEST_JSON)
     @test html2 == html
 
+end
+
+@testset "Correct flag handling" begin
+    html = Quizify.build_quiz_html(TEST_JSON_ALT)
+    @test occursin("Well done", html) # feedback is present
+    # The second answer is marked correct via the `correct` flag even though the feedback doesn't start with "correct".
+    @test occursin("onclick=\"handleAnswer('1', 'q1_a2', 'Well done', true)\"", html)
 end

--- a/test/test_quiz_alt.json
+++ b/test/test_quiz_alt.json
@@ -1,0 +1,10 @@
+[
+    {
+        "question": "Alt Question 1",
+        "type": "many_choice",
+        "answers": [
+            {"answer": "A1", "correct": false, "feedback": "Nope"},
+            {"answer": "A2", "correct": true,  "feedback": "Well done"}
+        ]
+    }
+]


### PR DESCRIPTION
## Summary
- fix detection of correct answers by reading the `correct` field in the quiz data
- add regression test ensuring the flag works even when feedback text doesn't start with "correct"

## Testing
- `julia --project=test -e 'using Pkg; Pkg.test()'` *(fails: `julia` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684136e5d65c8324aa5de10e662c5e68