### PR TITLE
Extend quiz types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs](https://github.com/berrli/Quizify.jl/actions/workflows/ci.yml/badge.svg?event=push)](https://berrli.github.io/Quizify.jl/)  
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Quizify.jl is a Julia package that converts quiz questions defined in a JSON file into an interactive HTML snippet, perfect for embedding in web-based course materials. It supports multiple-choice quizzes with styled buttons and immediate feedback—no server or backend required.
+Quizify.jl is a Julia package that converts quiz questions defined in a JSON file into an interactive HTML snippet, perfect for embedding in web-based course materials. It now supports several common quiz formats with styled widgets and immediate feedback—no server or backend required.
 
 ---
 
@@ -15,9 +15,41 @@ Quizify.jl is a Julia package that converts quiz questions defined in a JSON fil
   Define your quiz as an array of question objects (see example below).
 - **Self-contained HTML**  
   Includes built-in CSS and JavaScript so you can embed the output directly.
-- **Immediate feedback**  
+- **Immediate feedback**
   Highlights correct answers in green and incorrect ones in red, and displays feedback text.
-- **Zero dependencies** beyond JSON.jl  
+- **Zero dependencies** beyond JSON.jl
   No frameworks or web servers—just Julia and a browser or notebook.
+- **Multiple question types**
+  Support for single choice, true/false and short-answer questions out of the box.
 
 ---
+
+## Example JSON
+
+```json
+[
+  {
+    "question": "Select the correct option",
+    "type": "many_choice",
+    "answers": [
+      {"answer": "A", "correct": false, "feedback": "Try again"},
+      {"answer": "B", "correct": true,  "feedback": "Correct!"}
+    ]
+  },
+  {
+    "question": "The Earth is round",
+    "type": "true_false",
+    "correct": true,
+    "feedback_true": "Correct",
+    "feedback_false": "Incorrect"
+  },
+  {
+    "question": "Chemical symbol for water",
+    "type": "short_answer",
+    "correct_answer": "H2O",
+    "feedback_correct": "Correct",
+    "feedback_incorrect": "Incorrect"
+  }
+]
+```
+

--- a/src/Quizify.jl
+++ b/src/Quizify.jl
@@ -5,6 +5,13 @@ using JSON
 export show_quiz_from_json
 
 """
+    escapejs(s::AbstractString) -> String
+
+Escape a Julia string for safe interpolation inside JavaScript single quotes.
+"""
+escapejs(s::AbstractString) = replace(replace(s, "\\" => "\\\\"), "'" => "\\'")
+
+"""
     build_quiz_html(path::AbstractString) -> String
 
 Read quiz data from the JSON file at `path` and return the complete
@@ -43,6 +50,7 @@ function build_quiz_html(path::AbstractString)::String
     .correct { background-color: #4CAF50 !important; color: white !important; border: none; }
     .incorrect { background-color: #D32F2F !important; color: white !important; border: none; }
     .feedback { margin-top: 10px; font-weight: bold; font-size: 1em; }
+    .quiz-text { width: 100%; padding: 10px; margin: 5px 0; border-radius: 10px; border: 1px solid #ccc; }
     </style>
 
     <script>
@@ -60,6 +68,23 @@ function build_quiz_html(path::AbstractString)::String
         feedbackBox.innerHTML = feedback;
         feedbackBox.style.color = isCorrect ? 'green' : 'red';
     }
+
+    function handleTextAnswer(qid, correctAnswer, fbCorrect, fbIncorrect) {
+        let input = document.getElementById('input_' + qid);
+        let ans = input.value.trim();
+        let feedbackBox = document.getElementById('feedback_' + qid);
+        if(ans.toLowerCase() === correctAnswer.toLowerCase()) {
+            feedbackBox.innerHTML = fbCorrect;
+            feedbackBox.style.color = 'green';
+            input.classList.add('correct');
+            input.classList.remove('incorrect');
+        } else {
+            feedbackBox.innerHTML = fbIncorrect;
+            feedbackBox.style.color = 'red';
+            input.classList.add('incorrect');
+            input.classList.remove('correct');
+        }
+    }
     </script>
 
     <div class="quiz">
@@ -67,24 +92,56 @@ function build_quiz_html(path::AbstractString)::String
 
     # Questions
     for (i, question) in enumerate(quiz_data)
-        qid = string(i)
+        qid   = string(i)
+        qtype = get(question, "type", "many_choice")
+
         html *= """
         <div class="quiz-question">$(question["question"])</div>
         <form class="quiz-form">
         """
 
-        for (j, answer) in enumerate(question["answers"])
-            aid      = "q$(i)_a$(j)"
-            feedback = answer["feedback"]
-            correct  = startswith(lowercase(feedback), "correct")
+        if qtype == "many_choice" || qtype == "single_choice"
+            for (j, answer) in enumerate(question["answers"])
+                aid      = "q$(i)_a$(j)"
+                feedback = answer["feedback"]
+                correct  = get(answer, "correct", false)
+                html *= """
+                <button type="button"
+                        class="quiz-answer answer-$(qid)"
+                        id="$(aid)"
+                        onclick="handleAnswer('$(qid)', '$(aid)', '$(escapejs(feedback))', $(correct))">
+                    $(answer["answer"])
+                </button>
+                """
+            end
+        elseif qtype == "true_false"
+            correct = question["correct"]
+            fb_true = question["feedback_true"]
+            fb_false = question["feedback_false"]
             html *= """
             <button type="button"
                     class="quiz-answer answer-$(qid)"
-                    id="$(aid)"
-                    onclick="handleAnswer('$(qid)', '$(aid)', '$(feedback)', $(correct))">
-                $(answer["answer"])
+                    id="q$(i)_true"
+                    onclick="handleAnswer('$(qid)', 'q$(i)_true', '$(escapejs(fb_true))', $(correct==true))">
+                True
+            </button>
+            <button type="button"
+                    class="quiz-answer answer-$(qid)"
+                    id="q$(i)_false"
+                    onclick="handleAnswer('$(qid)', 'q$(i)_false', '$(escapejs(fb_false))', $(correct==false))">
+                False
             </button>
             """
+        elseif qtype == "short_answer"
+            correct_answer = question["correct_answer"]
+            fb_correct = question["feedback_correct"]
+            fb_incorrect = question["feedback_incorrect"]
+            html *= """
+            <input type="text" class="quiz-text" id="input_$(qid)" />
+            <button type="button" class="quiz-answer" onclick="handleTextAnswer('$(qid)', '$(escapejs(correct_answer))', '$(escapejs(fb_correct))', '$(escapejs(fb_incorrect))')">Submit</button>
+            """
+        else
+            error("Unknown question type: $(qtype)")
         end
 
         html *= """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,14 +10,18 @@ const TEST_JSON = joinpath(@__DIR__, "test_quiz.json")
     html = Quizify.build_quiz_html(TEST_JSON)
     @test typeof(html) == String
 
-    # 2) Check that both questions appear
+    # 2) Check that all questions appear
     @test occursin("Question 1", html)
     @test occursin("Question 2", html)
+    @test occursin("The sky is blue", html)
+    @test occursin("Chemical symbol for water", html)
 
-    # 3) Verify the correct-answer buttons have the right IDs
+    # 3) Verify the correct-answer buttons and inputs have the right IDs
     #    (Q1’s correct answer is at j=2 → id="q1_a2"; Q2’s at j=3 → id="q2_a3")
     @test occursin("id=\"q1_a2\"", html)
     @test occursin("id=\"q2_a3\"", html)
+    @test occursin("id=\"q3_true\"", html)
+    @test occursin("id=\"input_4\"", html)
 
     # 4) Make sure the CSS and JS blocks are present
     @test occursin("<style>",  html)

--- a/test/test_quiz.json
+++ b/test/test_quiz.json
@@ -50,5 +50,19 @@
                 "feedback": "Incorrect"
             }
         ]
+    },
+    {
+        "question": "The sky is blue",
+        "type": "true_false",
+        "correct": true,
+        "feedback_true": "Correct",
+        "feedback_false": "Incorrect"
+    },
+    {
+        "question": "Chemical symbol for water",
+        "type": "short_answer",
+        "correct_answer": "H2O",
+        "feedback_correct": "Correct",
+        "feedback_incorrect": "Incorrect"
     }
 ]


### PR DESCRIPTION
## Summary
- support more quiz formats in `build_quiz_html`
- escape text for javascript output
- expand README with new quiz types and example
- add true/false and short-answer examples to test fixture
- update tests for new content

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: `julia` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413838e72c8324a9adeb8fbcfab3f9