### PR TITLE
Enhance README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,56 @@ Quizify.jl is a Julia package that converts quiz questions defined in a JSON fil
   No frameworks or web servers—just Julia and a browser or notebook.
 
 ---
+
+## Installation
+
+Install the package using Julia's package manager:
+
+```julia
+julia> using Pkg
+julia> Pkg.add(url="https://github.com/berrli/Quizify.jl")
+```
+
+(If the package is registered you can simply run `Pkg.add("Quizify")`.)
+
+## Defining a Quiz
+
+Create a JSON file where each object represents a question and its possible answers. A minimal example `myquiz.json` might look like
+
+```json
+[
+  {
+    "question": "What is 2 + 2?",
+    "answers": [
+      {"answer": "3", "correct": false, "feedback": "Try again"},
+      {"answer": "4", "correct": true,  "feedback": "Correct!"}
+    ]
+  }
+]
+```
+
+## Using Quizify
+
+Rendering the quiz is a single call to `show_quiz_from_json`:
+
+```julia
+using Quizify
+
+html = show_quiz_from_json("myquiz.json")
+```
+
+In a notebook environment the HTML quiz appears inline. In a plain REPL the
+HTML is printed and also returned so you can write it to a file:
+
+```julia
+write("quiz.html", html)
+```
+
+If you only need the HTML string without displaying it, use the lower level
+`build_quiz_html` function:
+
+```julia
+html = build_quiz_html("myquiz.json")
+```
+
+You can then embed that HTML snippet into any webpage.


### PR DESCRIPTION
## Summary
- add installation steps
- document JSON quiz format
- provide example of using `show_quiz_from_json` and `build_quiz_html`

## Testing
- `julia -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841407d94f483249abf2f6f2981c68a