### PR TITLE
Add score summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Quizify.jl is a Julia package that converts quiz questions defined in a JSON fil
   No frameworks or web servers—just Julia and a browser or notebook.
 - **Multiple question types**
   Support for single choice, true/false and short-answer questions out of the box.
-- **Score summary**
-  Shows a progress bar with your final score once all questions are answered.
+- **Score summary & chart**
+  Displays a progress bar and bar chart of correct answers once all questions are completed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Quizify.jl is a Julia package that converts quiz questions defined in a JSON fil
   No frameworks or web servers—just Julia and a browser or notebook.
 - **Multiple question types**
   Support for single choice, true/false and short-answer questions out of the box.
+- **Score summary**
+  Shows a progress bar with your final score once all questions are answered.
 
 ---
 

--- a/src/Quizify.jl
+++ b/src/Quizify.jl
@@ -51,9 +51,30 @@ function build_quiz_html(path::AbstractString)::String
     .incorrect { background-color: #D32F2F !important; color: white !important; border: none; }
     .feedback { margin-top: 10px; font-weight: bold; font-size: 1em; }
     .quiz-text { width: 100%; padding: 10px; margin: 5px 0; border-radius: 10px; border: 1px solid #ccc; }
+    .results-container { margin-top: 20px; font-weight: bold; }
+    .score-bar-bg { background-color: #f2f2f2; border-radius: 10px; height: 20px; width: 100%; }
+    .score-bar-fill { background-color: #6c63ff; height: 100%; border-radius: 10px; width: 0%; transition: width 0.5s; }
     </style>
 
     <script>
+    var quizResults = {};
+    var totalQuestions = $(length(quiz_data));
+
+    function updateResults(qid, isCorrect) {
+        quizResults[qid] = isCorrect;
+        if (Object.keys(quizResults).length === totalQuestions) {
+            showFinalResults();
+        }
+    }
+
+    function showFinalResults() {
+        let correct = Object.values(quizResults).filter(x => x).length;
+        document.getElementById('score-text').innerHTML =
+            `Score: ${correct} / ${totalQuestions}`;
+        document.getElementById('score-fill').style.width =
+            (100 * correct / totalQuestions) + '%';
+        document.getElementById('quiz-results').style.display = 'block';
+    }
     function handleAnswer(qid, aid, feedback, isCorrect) {
         // Reset all buttons for the question
         let buttons = document.querySelectorAll(".answer-" + qid);
@@ -67,6 +88,7 @@ function build_quiz_html(path::AbstractString)::String
         let feedbackBox = document.getElementById('feedback_' + qid);
         feedbackBox.innerHTML = feedback;
         feedbackBox.style.color = isCorrect ? 'green' : 'red';
+        updateResults(qid, isCorrect);
     }
 
     function handleTextAnswer(qid, correctAnswer, fbCorrect, fbIncorrect) {
@@ -84,6 +106,7 @@ function build_quiz_html(path::AbstractString)::String
             input.classList.add('incorrect');
             input.classList.remove('correct');
         }
+        updateResults(qid, ans.toLowerCase() === correctAnswer.toLowerCase());
     }
     </script>
 
@@ -150,7 +173,14 @@ function build_quiz_html(path::AbstractString)::String
         """
     end
 
-    html *= "</div>\n"
+    html *= """
+        <div class="results-container" id="quiz-results" style="display:none;">
+            <div class="score-bar-bg">
+                <div class="score-bar-fill" id="score-fill"></div>
+            </div>
+            <div id="score-text"></div>
+        </div>
+    </div>\n"""
     return html
 end
 

--- a/src/Quizify.jl
+++ b/src/Quizify.jl
@@ -74,6 +74,23 @@ function build_quiz_html(path::AbstractString)::String
         document.getElementById('score-fill').style.width =
             (100 * correct / totalQuestions) + '%';
         document.getElementById('quiz-results').style.display = 'block';
+        drawChart();
+    }
+
+    function drawChart() {
+        let canvas = document.getElementById('result-chart');
+        if (!canvas) return;
+        let ctx = canvas.getContext('2d');
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        let barWidth = 20;
+        let gap = 10;
+        let maxHeight = canvas.height - 20;
+        Object.keys(quizResults).forEach((qid, idx) => {
+            ctx.fillStyle = quizResults[qid] ? '#4CAF50' : '#D32F2F';
+            let x = idx * (barWidth + gap);
+            let height = maxHeight;
+            ctx.fillRect(x, canvas.height - height, barWidth, height);
+        });
     }
     function handleAnswer(qid, aid, feedback, isCorrect) {
         // Reset all buttons for the question
@@ -179,6 +196,7 @@ function build_quiz_html(path::AbstractString)::String
                 <div class="score-bar-fill" id="score-fill"></div>
             </div>
             <div id="score-text"></div>
+            <canvas id="result-chart" width="300" height="100"></canvas>
         </div>
     </div>\n"""
     return html

--- a/src/Quizify.jl
+++ b/src/Quizify.jl
@@ -70,7 +70,7 @@ function build_quiz_html(path::AbstractString)::String
     function showFinalResults() {
         let correct = Object.values(quizResults).filter(x => x).length;
         document.getElementById('score-text').innerHTML =
-            `Score: ${correct} / ${totalQuestions}`;
+            `Score: \${correct} / \${totalQuestions}`;
         document.getElementById('score-fill').style.width =
             (100 * correct / totalQuestions) + '%';
         document.getElementById('quiz-results').style.display = 'block';

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ const TEST_JSON_ALT = joinpath(@__DIR__, "test_quiz_alt.json")
     @test occursin("<style>",  html)
     @test occursin("<script>", html)
     @test occursin("id=\"quiz-results\"", html)
+    @test occursin("id=\"result-chart\"", html)
 
     # 5) show_quiz_from_json should return exactly the same HTML string
     html2 = Quizify.show_quiz_from_json(TEST_JSON)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ const TEST_JSON_ALT = joinpath(@__DIR__, "test_quiz_alt.json")
     # 4) Make sure the CSS and JS blocks are present
     @test occursin("<style>",  html)
     @test occursin("<script>", html)
+    @test occursin("id=\"quiz-results\"", html)
 
     # 5) show_quiz_from_json should return exactly the same HTML string
     html2 = Quizify.show_quiz_from_json(TEST_JSON)


### PR DESCRIPTION
## Summary
- add score summary after quiz completion
- test that results container is in the HTML
- document new score summary feature

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684155acebf8832480724c07f61e7b77